### PR TITLE
feat: allow tuples of any size in dynamic keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lukemorales/query-key-factory
 
+## 0.3.0
+
+### Minor Changes
+
+- Allow tuples of any size in dynamic keys
+
 ## 0.2.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ const ProductList: FC = () => {
 
   useEffect(() => {
     if (search === '') {
-      queryClient.invalidateQueries(productKeys.search.toScope()); // invalidate cache only for the search scope
+      queryClient.invalidateQueries(productKeys.search.toScope());
+      // invalidate cache only for the search scope
     }
   }, [search]);
 
@@ -73,7 +74,8 @@ const Product: FC = () => {
   const product = useQuery(productsKeys.byId(productId), fetchProduct);
 
   const onAddToCart = () => {
-    queryClient.invalidateQueries(productsKeys.default); // invalidade cache for entire feature
+    queryClient.invalidateQueries(productsKeys.default);
+    // invalidade cache for entire feature
   }
 
   return <div> {/* render product page */} </div>;
@@ -110,12 +112,18 @@ const todosKeys = createQueryKeys('todos', {
   single: (id: string) => id,
   tag: (tagId: string) => ({ tagId }),
   search: (query: string, limit: number) => [query, { limit }],
+  filter: ({ filter, status, limit }: FilterOptions) => [filter, status, limit],
 });
 
 
-todosKeys.single('todo_id'); // ['todos', 'single', 'todo_id']
-todosKeys.tag('tag_homework'); // ['todos', 'tag', { tagId: 'tag_homework' }]
-todosKeys.search('learn tanstack query', 15); // ['todos', 'search', 'learn tanstack query', { limit: 15 }]
+todosKeys.single('todo_id');
+// ['todos', 'single', 'todo_id']
+todosKeys.tag('tag_homework');
+// ['todos', 'tag', { tagId: 'tag_homework' }]
+todosKeys.search('learn tanstack query', 15);
+// ['todos', 'search', 'learn tanstack query', { limit: 15 }]
+todosKeys.filter('not-owned-by-me', 'done', 15);
+// ['todos', 'filter', 'not-owned-by-me', 'done', 15]
 
 todosKeys.single.toScope(); // ['todos', 'single']
 todosKeys.tag.toScope(); // ['todos', 'tag']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukemorales/query-key-factory",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/lukemorales/query-key-factory.git"

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -110,18 +110,53 @@ describe('createQueryKeys', () => {
       });
 
       describe('when the function returns a tuple', () => {
+        type TodoStatus = 'done' | 'ongoing';
+
+        type Test = {
+          id: string;
+          preview: boolean;
+          status: TodoStatus;
+          tasksPerPage: number;
+        };
+
         it('creates a function that returns a formatted query key when the result is an array', () => {
           const queryKeys = createQueryKeys('master-key', {
-            todoWithPreview: <Id extends string>(id: Id, preview: boolean) => [id, { preview }],
+            todoKeyWithTuple: ({ id, preview, status, tasksPerPage }: Test) => [id, preview, status, tasksPerPage],
+            todoKeyWithRecord: (id: string, preview: boolean) => [id, { preview }],
           });
 
-          expect(typeof queryKeys.todoWithPreview).toBe('function');
+          expect(typeof queryKeys.todoKeyWithTuple).toBe('function');
+          expect(typeof queryKeys.todoKeyWithRecord).toBe('function');
 
-          const generatedKey = queryKeys.todoWithPreview('todo-id', false);
+          const generatedKeyWithTuple = queryKeys.todoKeyWithTuple({
+            //  ^?
+            id: 'ongoing-todo-id',
+            preview: true,
+            status: 'ongoing',
+            tasksPerPage: 3,
+          });
+          const generatedKeyWithRecord = queryKeys.todoKeyWithRecord('todo-id', false);
+          //    ^?
 
-          expect(Array.isArray(generatedKey)).toBeTruthy();
-          expect(generatedKey).toHaveLength(4);
-          expect(generatedKey).toStrictEqual(['master-key', 'todoWithPreview', 'todo-id', { preview: false }]);
+          expect(Array.isArray(generatedKeyWithTuple)).toBeTruthy();
+          expect(generatedKeyWithTuple).toHaveLength(6);
+          expect(generatedKeyWithTuple).toStrictEqual([
+            'master-key',
+            'todoKeyWithTuple',
+            'ongoing-todo-id',
+            true,
+            'ongoing',
+            3,
+          ]);
+
+          expect(Array.isArray(generatedKeyWithRecord)).toBeTruthy();
+          expect(generatedKeyWithRecord).toHaveLength(4);
+          expect(generatedKeyWithRecord).toStrictEqual([
+            'master-key',
+            'todoKeyWithRecord',
+            'todo-id',
+            { preview: false },
+          ]);
         });
       });
 


### PR DESCRIPTION
This PR improves type-inference allowing dynamic keys to return tuples of any size.

Testes were added and docs updated with new examples