### PR TITLE
docs: update example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ todosKeys.tag('tag_homework');
 // ['todos', 'tag', { tagId: 'tag_homework' }]
 todosKeys.search('learn tanstack query', 15);
 // ['todos', 'search', 'learn tanstack query', { limit: 15 }]
-todosKeys.filter('not-owned-by-me', 'done', 15);
+todosKeys.filter({ filter: 'not-owned-by-me', status: 'done', limit: 15 });
 // ['todos', 'filter', 'not-owned-by-me', 'done', 15]
 
 todosKeys.single.toScope(); // ['todos', 'single']


### PR DESCRIPTION

Issue: 
In the readme, the example in line 125  was confusing and misleading.
As per the example factor `filter: ({ filter, status, limit }: FilterOptions) => [filter, status, limit],` but in the call `todosKeys.filter('not-owned-by-me', 'done', 15);` which is a mistake.  

Solution:
I have verified test case and the usage https://github.com/lukemorales/query-key-factory/blob/8278ce5dcade451ee4736a1108493efc4866e947/src/create-query-keys.spec.ts#L131 

It feels like a simple typo mistake. 