### PR TITLE
feat: create `mergeQueryKeys` util

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ todosKeys = {
   done: ['todos', 'done'],
   preview: ['todos', 'preview', true],
   single: ('todo_id') => ['todos', 'single', 'todo_id'],
-}
+};
 ```
 
 ### Access to serializable keys scoped form
@@ -130,8 +130,42 @@ todosKeys.tag.toScope(); // ['todos', 'tag']
 todosKeys.search.toScope(); // ['todos', 'search']
 ```
 
-### Type your QueryFunctionContext
-Get types of your query keys passed to the queryFn
+### Create a single point of access for all your query keys
+Have fine-grained control over your features' keys and merge them into a single object to have access to all your query keys in your codebase:
+
+```ts
+const usersKeys = createQueryKeys('users', {
+  byId: (id: string) => id,
+});
+
+const todosKeys = createQueryKeys('todos', {
+  done: null,
+  preview: true,
+  single: (id: string) => id,
+});
+
+
+export const keysStore = mergeQueryKeys(usersKeys, todosKeys);
+export type KeysStore = inferMergedFactory<typeof keysStore>;
+
+// shape of mergeQueryKeys output
+keysStore = {
+  users: {
+    default: ['users'],
+    byId: (id: string) => id,
+  },
+  todos: {
+    default: ['todos'],
+    done: ['todos', 'done'],
+    preview: ['todos', 'preview', true],
+    single: (id: string) => id,
+  },
+};
+```
+
+### Type your QueryFunctionContext with ease
+Get accurate types of your query keys passed to the `queryFn` context:
+
 ```ts
 import { createQueryKeys, inferQueryKeys } from "@lukemorales/query-key-factory"
 
@@ -145,11 +179,10 @@ const todosKeys = createQueryKeys('todos', {
 type TodoKeys = inferQueryKeys<typeof todosKeys>
 
 const fetchTodosByTag = (context: QueryFunctionContext<TodoKeys['tag']>) => {
-  const queryKey = context.queryKey // readonly ['todos', 'tag', { tagId: string }] 
+  const queryKey = context.queryKey // readonly ['todos', 'tag', { tagId: string }]
 
   // fetch todos...
 }
 
 useQuery(todosKeys.tag('tag_homework'), fetchTodosByTag)
 ```
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { createQueryKeys } from './create-query-keys';
-export type { inferQueryKeys } from './types';
+export { mergeQueryKeys } from './merge-query-keys';
+export type { inferQueryKeys, inferMergedFactory } from './types';

--- a/src/merge-query-keys.spec.ts
+++ b/src/merge-query-keys.spec.ts
@@ -1,0 +1,28 @@
+import { createQueryKeys } from './create-query-keys';
+import { mergeQueryKeys } from './merge-query-keys';
+
+describe('mergeQueryKeys', () => {
+  const performSetup = () => {
+    const usersKeys = createQueryKeys('users');
+    const todosKeys = createQueryKeys('todos', {
+      done: null,
+      todo: (id: string) => id,
+    });
+
+    return { usersKeys, todosKeys };
+  };
+
+  it('merges the keys into a single factory object using their default keys as the object properties', () => {
+    const { usersKeys, todosKeys } = performSetup();
+
+    const keysFactory = mergeQueryKeys(usersKeys, todosKeys);
+
+    expect(keysFactory).toHaveProperty('users');
+    expect(keysFactory).toHaveProperty('todos');
+
+    expect(keysFactory).toStrictEqual({
+      users: usersKeys,
+      todos: todosKeys,
+    });
+  });
+});

--- a/src/merge-query-keys.ts
+++ b/src/merge-query-keys.ts
@@ -1,0 +1,14 @@
+import { AnyFactoryOutput, FactoryFromMergedQueryKeys } from './types';
+
+export function mergeQueryKeys<FactoryOutputs extends AnyFactoryOutput[]>(
+  ...schemas: FactoryOutputs
+): FactoryFromMergedQueryKeys<FactoryOutputs> {
+  const factory = schemas.reduce((factoryMap, current) => {
+    const [factoryKey] = current.default;
+
+    factoryMap.set(factoryKey, current);
+    return factoryMap;
+  }, new Map());
+
+  return Object.fromEntries(factory);
+}

--- a/src/types.utils.ts
+++ b/src/types.utils.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// See https://github.com/Microsoft/TypeScript/issues/26223#issuecomment-674514787 for original types
+type BuildPowersOf2LengthArrays<N extends number, R extends never[][]> = R[0][N] extends never
+  ? R
+  : BuildPowersOf2LengthArrays<N, [[...R[0], ...R[0]], ...R]>;
+
+type ConcatLargestUntilDone<N extends number, R extends never[][], B extends never[]> = B['length'] extends N
+  ? B
+  : [...R[0], ...B][N] extends never
+  ? ConcatLargestUntilDone<N, R extends [R[0], ...infer U] ? (U extends never[][] ? U : never) : never, B>
+  : ConcatLargestUntilDone<
+      N,
+      R extends [R[0], ...infer U] ? (U extends never[][] ? U : never) : never,
+      [...R[0], ...B]
+    >;
+
+type Replace<R extends any[], T> = { [K in keyof R]: T };
+
+type TupleOf<T, N extends number> = number extends N
+  ? T[]
+  : {
+      [K in N]: BuildPowersOf2LengthArrays<K, [[never]]> extends infer U
+        ? U extends never[][]
+          ? Replace<ConcatLargestUntilDone<K, U, []>, T>
+          : never
+        : never;
+    }[N];
+
+type Length<T extends any[]> = T extends { length: infer L } ? L : never;
+
+export type Add<A extends number, B extends number> = Length<[...TupleOf<any, A>, ...TupleOf<any, B>]>;


### PR DESCRIPTION
Inspired by #8 discussion and tRPC merge router API, this adds the `mergeQueryKeys` util that merges all provided query keys result into a single object