### PR TITLE
feat: create \`createQueryKeyStore`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,15 @@
     }],
     "no-shadow": "off",
     "prefer-template": "error",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "{}": false
+        },
+        "extendDefaults": true
+      }
+    ],
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-useless-constructor": "error",
     "@typescript-eslint/indent": "off",

--- a/src/create-query-key-store.spec.ts
+++ b/src/create-query-key-store.spec.ts
@@ -1,0 +1,29 @@
+import { createQueryKeyStore } from './create-query-key-store';
+
+describe('createQueryKeyStore', () => {
+  it('creates a store from the schema provided as argument', () => {
+    const store = createQueryKeyStore({
+      users: null,
+      todos: {
+        done: null,
+        todo: (id: string) => id,
+      },
+    });
+
+    expect(Object.keys(store)).toHaveLength(2);
+
+    expect(store).toHaveProperty('users');
+    expect(store).toHaveProperty('todos');
+
+    expect(store).toStrictEqual({
+      users: {
+        default: ['users'],
+      },
+      todos: {
+        default: ['todos'],
+        done: ['todos', 'done'],
+        todo: expect.any(Function),
+      },
+    });
+  });
+});

--- a/src/create-query-key-store.ts
+++ b/src/create-query-key-store.ts
@@ -1,0 +1,19 @@
+import { createQueryKeys } from './create-query-keys';
+import { QueryKeyStoreSchema, QueryKeyStore } from './types';
+
+export function createQueryKeyStore<StoreSchema extends QueryKeyStoreSchema>(
+  storeSchema: StoreSchema,
+): QueryKeyStore<StoreSchema> {
+  const storeKeys = Object.keys(storeSchema);
+
+  const store = storeKeys.reduce((storeMap, key) => {
+    const scopeFactory = storeSchema[key];
+
+    const factoryResult = scopeFactory ? createQueryKeys(key, scopeFactory) : createQueryKeys(key);
+
+    storeMap.set(key, factoryResult);
+    return storeMap;
+  }, new Map());
+
+  return Object.fromEntries(store);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { createQueryKeyStore } from './create-query-key-store';
 export { createQueryKeys } from './create-query-keys';
 export { mergeQueryKeys } from './merge-query-keys';
-export type { inferQueryKeys, inferMergedFactory } from './types';
+export type { inferQueryKeys, inferMergedStore, inferMergedFactory, inferQueryKeyStore } from './types';

--- a/src/merge-query-keys.ts
+++ b/src/merge-query-keys.ts
@@ -1,8 +1,8 @@
-import { AnyFactoryOutput, FactoryFromMergedQueryKeys } from './types';
+import { AnyQueryKeyFactoryResult, StoreFromMergedQueryKeys } from './types';
 
-export function mergeQueryKeys<FactoryOutputs extends AnyFactoryOutput[]>(
+export function mergeQueryKeys<FactoryOutputs extends AnyQueryKeyFactoryResult[]>(
   ...schemas: FactoryOutputs
-): FactoryFromMergedQueryKeys<FactoryOutputs> {
+): StoreFromMergedQueryKeys<FactoryOutputs> {
   const factory = schemas.reduce((factoryMap, current) => {
     const [factoryKey] = current.default;
 


### PR DESCRIPTION
This PR adds the `createQueryKeyStore` that unlocks declaring all your query keys in a single function call and resolves #8 as the way to support at least one level of nesting