### PR TITLE
fix: remove arrays from being proxied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lukemorales/query-key-factory
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix query key breaking devtools because of Proxy
+
 ## 0.6.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukemorales/query-key-factory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/lukemorales/query-key-factory.git"

--- a/src/internals/with-deprecated-api.ts
+++ b/src/internals/with-deprecated-api.ts
@@ -10,7 +10,10 @@ export const withDeprecatedApi = <T extends Record<string, unknown>>(schema: T) 
     get(target, property, receiver) {
       const originalValue = Reflect.get(target, property, receiver);
 
-      if (typeof originalValue === 'function' || (typeof originalValue === 'object' && originalValue != null)) {
+      if (
+        typeof originalValue === 'function' ||
+        (typeof originalValue === 'object' && !Array.isArray(originalValue) && originalValue != null)
+      ) {
         return new Proxy(originalValue, handler);
       }
 


### PR DESCRIPTION
This PR fixes arrays losing prototype because of Proxy and caused to break when accessing a query in the React Query Devtools

Resolves #15 