### PR TITLE
feat: allow declaring query options with only `queryKey`

### DIFF
--- a/.changeset/olive-zoos-wash.md
+++ b/.changeset/olive-zoos-wash.md
@@ -2,6 +2,121 @@
 '@lukemorales/query-key-factory': major
 ---
 
-Generate query options and add support for nested keys
+## Generate query options and add support for nested keys
 
-BREAKING CHANGE: All intended query key returned values should now be an array. Object returns are now used to declare query key, query fn and/or nested keys.
+New in `@lukemorales/query-key-factory` is support for nested keys and generation of query options, adopting the query options overload as first class citizen, in preparation for [React Query v5 roadmap](https://github.com/TanStack/query/discussions/4252).
+
+```ts
+const people = createQueryKeys("people", {
+  person: (id: number) => ({
+    queryKey: [id],
+    queryFn: () => api.getPerson({ params: { id } }),
+    context: {
+      ships: {
+        queryKey: null,
+        queryFn: () => api.getShipsByPerson({
+          params: { personId: id },
+        }),
+      },
+      film: (filmId: string) => ({
+        queryKey: [filmId],
+        queryFn: () => api.getFilm({
+          params: { id: filmId },
+        }),
+      }),
+    },
+  }),
+});
+```
+
+Each entry outputs an object that can be used in the query options overload in React Query:
+```tsx
+console.log(people.person('person_01'));
+
+// => output:
+// {
+//   queryKey: ['people', 'person', 'person_01'],
+//   queryFn: () => api.getPerson({ params: { id: 'person_01' } }),
+//   _ctx: { ...queries declared inside "context" }
+// }
+```
+
+Then you can easily just use the object in `useQuery` or spread it and add more query options to that observer:
+```tsx
+export const Person = ({ id }) => {
+  const personQuery = useQuery(people.person(id));
+
+  return  ( {/* render person data */} );
+};
+
+export const Ships = ({ personId }) => {
+  const shipsQuery = useQuery({
+    ...people.person(personId)._ctx.ships,
+    enabled: !!personId,
+  });
+
+  return ( {/* render ships data */} );
+};
+
+export const Film = ({ id, personId }) => {
+  const filmQuery = useQuery(people.person(personId)._ctx.film(id));
+
+  return ( {/* render film data */} );
+};
+```
+
+### BREAKING CHANGES
+
+#### Standardized query key values
+All query key values should now be an array. Only the first level keys (those not dynamically generated) can still be declared as `null`, but if you want to pass a value, you will need to make it an array.
+
+```diff
+export const todosKeys = createQueryKeys('todos', {
+  mine: null,
+- all: 'all-todos',
++ all: ['all-todos'],
+- list: (filters: TodoFilters) => ({ filters }),
++ list: (filters: TodoFilters) => [{ filters }],
+- todo: (todoId: string) => todoId,
++ todo: (todoId: string) => [todoId],
+});
+```
+
+#### Objects are now used to declare query options
+You can still use objects to compose a query key, but now they must be inside an array because plain objects are now used for the declaration of the query options:
+
+```diff
+export const todosKeys = createQueryKeys('todos', {
+- list: (filters: TodoFilters) => ({ filters }),
++ list: (filters: TodoFilters) => ({
++   queryKey: [{ filters }],
++ }),
+});
+```
+
+#### Generated output for a query key is always an object
+With the new API, the output of an entry will always be an object according to what options you've declared in the factory (e.g.: if you returned an array or declared an object with only `queryKey`, your output will be `{ queryKey: [...values] }`, if you also declared `queryFn` it will be added to that object, and `context` will be available inside `_ctx`):
+
+```diff
+export const todosKeys = createQueryKeys('todos', {
+  todo: (todoId: string) => [todoId],
+  list: (filters: TodoFilters) => {
+    queryKey: [{ filters }],
+    queryFn: () => fetchTodosList(filters),
+  },
+});
+
+- useQuery(todosKeys.todo(todoId), fetchTodo);
++ useQuery(todosKeys.todo(todoId).queryKey, fetchTodo);
+
+- useQuery(todosKeys.list(filters), fetchTodosList);
++ useQuery(todosKeys.list(filters).queryKey, todosKeys.list(filters).queryFn);
+
+// even better refactor, preparing for React Query v5
++ useQuery({
++   ...todosKeys.todo(todoId),
++   queryFn: fetchTodo,
++ });
+
++ useQuery(todosKeys.list(filters));
+```

--- a/.changeset/olive-zoos-wash.md
+++ b/.changeset/olive-zoos-wash.md
@@ -11,7 +11,7 @@ const people = createQueryKeys("people", {
   person: (id: number) => ({
     queryKey: [id],
     queryFn: () => api.getPerson({ params: { id } }),
-    context: {
+    contextQueries: {
       ships: {
         queryKey: null,
         queryFn: () => api.getShipsByPerson({
@@ -37,7 +37,7 @@ console.log(people.person('person_01'));
 // {
 //   queryKey: ['people', 'person', 'person_01'],
 //   queryFn: () => api.getPerson({ params: { id: 'person_01' } }),
-//   _ctx: { ...queries declared inside "context" }
+//   _ctx: { ...queries declared inside "contextQueries" }
 // }
 ```
 
@@ -95,7 +95,7 @@ export const todosKeys = createQueryKeys('todos', {
 ```
 
 #### Generated output for a query key is always an object
-With the new API, the output of an entry will always be an object according to what options you've declared in the factory (e.g.: if you returned an array or declared an object with only `queryKey`, your output will be `{ queryKey: [...values] }`, if you also declared `queryFn` it will be added to that object, and `context` will be available inside `_ctx`):
+With the new API, the output of an entry will always be an object according to what options you've declared in the factory (e.g.: if you returned an array or declared an object with only `queryKey`, your output will be `{ queryKey: [...values] }`, if you also declared `queryFn` it will be added to that object, and `contextQueries` will be available inside `_ctx`):
 
 ```diff
 export const todosKeys = createQueryKeys('todos', {

--- a/.changeset/slimy-books-yawn.md
+++ b/.changeset/slimy-books-yawn.md
@@ -2,6 +2,10 @@
 '@lukemorales/query-key-factory': major
 ---
 
-Remove deprecated `default` and `toScope` methods
+## Remove deprecated methods
+Since `v0.6.0`, the `default` key and and `toScope` method have been deprecated from the package.
 
-BREAKING CHANGE: `default` key and `toScope` method have been removed from the package.
+### BREAKING CHANGES
+
+### `default` and `toScope` removed from implementation
+`default` key and `toScope` method have been officially removed from the code, which means that if you try to access them, you will either receive `undefined` or your code will throw for trying to invoke a function on `toScope` that does not exist anymore.

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -90,6 +90,54 @@ describe('createQueryKeys', () => {
       });
 
       describe('when the property value is an object', () => {
+        describe('when the object has "queryKey"', () => {
+          describe('when the queryKey value is NULL', () => {
+            it('returns an object with queryKey in the shape [key, schema.property]', () => {
+              const sut = createQueryKeys('test', {
+                prop: {
+                  queryKey: null,
+                },
+              });
+
+              expect(sut).toHaveProperty('_def');
+              expect(sut).toHaveProperty('prop');
+
+              expect(sut).toEqual({
+                _def: ['test'],
+                prop: {
+                  queryKey: ['test', 'prop'],
+                },
+              });
+
+              expect(sut.prop).toHaveType<{
+                queryKey: readonly ['test', 'prop'];
+              }>();
+            });
+          });
+
+          describe('when the queryKey value is a tuple', () => {
+            it('returns an object with queryKey in the shape [prop, schema.property, value]', () => {
+              const sut = createQueryKeys('test', {
+                prop: {
+                  queryKey: ['value'],
+                },
+              });
+
+              expect(sut.prop.queryKey).toHaveLength(3);
+
+              expect(sut.prop).toEqual({
+                _def: ['test', 'prop'],
+                queryKey: ['test', 'prop', 'value'],
+              });
+
+              expect(sut.prop).toHaveType<{
+                _def: readonly ['test', 'prop'];
+                queryKey: readonly ['test', 'prop', string];
+              }>();
+            });
+          });
+        });
+
         describe('when the object has "queryKey" and "queryFn"', () => {
           describe('when the queryKey value is NULL', () => {
             it('returns an object with queryKey in the shape [key, schema.property]', () => {
@@ -353,6 +401,29 @@ describe('createQueryKeys', () => {
       });
 
       describe('when the function returns an object', () => {
+        describe('when the object has "queryKey"', () => {
+          it('creates a callback that returns "queryKey"', () => {
+            const sut = createQueryKeys('test', {
+              prop: (value: string) => ({
+                queryKey: [value],
+              }),
+            });
+
+            const result = sut.prop('value');
+            expect(result).toEqual({
+              queryKey: ['test', 'prop', 'value'],
+            });
+
+            expect(sut.prop).toHaveStrictType<
+              {
+                _def: readonly ['test', 'prop'];
+              } & ((value: string) => {
+                queryKey: readonly ['test', 'prop', string];
+              })
+            >();
+          });
+        });
+
         describe('when the object has "queryKey" and "queryFn"', () => {
           it('creates a callback that returns the query options', () => {
             const sut = createQueryKeys('test', {

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -192,13 +192,13 @@ describe('createQueryKeys', () => {
           });
         });
 
-        describe('when the object has "queryKey" and "context"', () => {
+        describe('when the object has "queryKey" and "contextQueries"', () => {
           describe('when the queryKey value is NULL', () => {
             it('returns an object with queryKey in the shape [key, schema.property]', () => {
               const sut = createQueryKeys('test', {
                 prop: {
                   queryKey: null,
-                  context: {
+                  contextQueries: {
                     'context-prop': null,
                   },
                 },
@@ -235,7 +235,7 @@ describe('createQueryKeys', () => {
               const sut = createQueryKeys('test', {
                 prop: {
                   queryKey: ['value'],
-                  context: {
+                  contextQueries: {
                     'context-prop': null,
                   },
                 },
@@ -266,14 +266,14 @@ describe('createQueryKeys', () => {
           });
         });
 
-        describe('when the object has "queryKey", "queryFn" and "context"', () => {
+        describe('when the object has "queryKey", "queryFn" and "contextQueries"', () => {
           describe('when the queryKey value is NULL', () => {
             it('returns an object with queryKey in the shape [key, schema.property]', () => {
               const sut = createQueryKeys('test', {
                 prop: {
                   queryKey: null,
                   queryFn: () => Promise.resolve(true),
-                  context: {
+                  contextQueries: {
                     'context-prop': null,
                   },
                 },
@@ -313,7 +313,7 @@ describe('createQueryKeys', () => {
                 prop: {
                   queryKey: ['value'],
                   queryFn: () => Promise.resolve(true),
-                  context: {
+                  contextQueries: {
                     'context-prop': null,
                   },
                 },
@@ -450,12 +450,12 @@ describe('createQueryKeys', () => {
           });
         });
 
-        describe('when the object has "queryKey" and "context"', () => {
+        describe('when the object has "queryKey" and "contextQueries"', () => {
           it('creates a callback that returns an object with queryKey and _ctx', () => {
             const sut = createQueryKeys('test', {
               prop: (value: string) => ({
                 queryKey: [value],
-                context: {
+                contextQueries: {
                   'context-prop': null,
                 },
               }),
@@ -487,13 +487,13 @@ describe('createQueryKeys', () => {
           });
         });
 
-        describe('when the object has "queryKey", "queryFn" and "context"', () => {
+        describe('when the object has "queryKey", "queryFn" and "contextQueries"', () => {
           it('creates a callback that returns an object with query options and _ctx', () => {
             const sut = createQueryKeys('test', {
               prop: (value: string) => ({
                 queryKey: [value],
                 queryFn: () => Promise.resolve(true),
-                context: {
+                contextQueries: {
                   'context-prop': null,
                 },
               }),
@@ -531,18 +531,18 @@ describe('createQueryKeys', () => {
   });
 });
 
-describe('createQueryKeys |> extrapolating context nesting', () => {
+describe('createQueryKeys |> extrapolating "contextQueries" nesting', () => {
   describe('when setting as a static key', () => {
     it('returns the expected types and shape', () => {
       const sut = createQueryKeys('test', {
         prop: {
           queryKey: null,
-          context: {
+          contextQueries: {
             nested1: null,
             nested2: ['context-prop-2'],
             nested3: (value: string) => ({
               queryKey: [value],
-              context: {
+              contextQueries: {
                 nested4: null,
               },
             }),
@@ -605,12 +605,12 @@ describe('createQueryKeys |> extrapolating context nesting', () => {
       const sut = createQueryKeys('test', {
         prop: (value: string) => ({
           queryKey: [value],
-          context: {
+          contextQueries: {
             nested1: null,
             nested2: ['context-prop-2'],
             nested3: (nestedValue: string) => ({
               queryKey: [nestedValue],
-              context: {
+              contextQueries: {
                 nested4: null,
               },
             }),

--- a/src/create-query-keys.ts
+++ b/src/create-query-keys.ts
@@ -55,8 +55,8 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
               queryFn: result.queryFn,
             };
 
-            if ('context' in result) {
-              const transformedSchema = transformSchema(result.context, innerKey);
+            if ('contextQueries' in result) {
+              const transformedSchema = transformSchema(result.contextQueries, innerKey);
 
               return omitPrototype({
                 _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
@@ -69,8 +69,8 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
             });
           }
 
-          if ('context' in result) {
-            const transformedSchema = transformSchema(result.context, innerKey);
+          if ('contextQueries' in result) {
+            const transformedSchema = transformSchema(result.contextQueries, innerKey);
 
             return omitPrototype({
               _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
@@ -106,8 +106,8 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
           queryFn: value.queryFn,
         };
 
-        if ('context' in value) {
-          const transformedSchema = transformSchema(value.context, innerKey);
+        if ('contextQueries' in value) {
+          const transformedSchema = transformSchema(value.contextQueries, innerKey);
 
           yieldValue = omitPrototype({
             _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
@@ -117,11 +117,11 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
         } else {
           yieldValue = omitPrototype({ ...innerDefKey, ...queryOptions });
         }
-      } else if ('context' in value) {
+      } else if ('contextQueries' in value) {
         const innerDefKey = { ...(value.queryKey ? { _def: key } : undefined) };
         const innerKey = [...key, ...(value.queryKey ?? [])] as const;
 
-        const transformedSchema = transformSchema(value.context, innerKey);
+        const transformedSchema = transformSchema(value.contextQueries, innerKey);
 
         yieldValue = omitPrototype({
           _ctx: omitPrototype(Object.fromEntries(transformedSchema)),

--- a/src/create-query-keys.ts
+++ b/src/create-query-keys.ts
@@ -69,10 +69,16 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
             });
           }
 
-          const transformedSchema = transformSchema(result.context, innerKey);
+          if ('context' in result) {
+            const transformedSchema = transformSchema(result.context, innerKey);
+
+            return omitPrototype({
+              _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
+              queryKey: innerKey,
+            });
+          }
 
           return omitPrototype({
-            _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
             queryKey: innerKey,
           });
         };
@@ -111,7 +117,7 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
         } else {
           yieldValue = omitPrototype({ ...innerDefKey, ...queryOptions });
         }
-      } else {
+      } else if ('context' in value) {
         const innerDefKey = { ...(value.queryKey ? { _def: key } : undefined) };
         const innerKey = [...key, ...(value.queryKey ?? [])] as const;
 
@@ -119,6 +125,14 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
 
         yieldValue = omitPrototype({
           _ctx: omitPrototype(Object.fromEntries(transformedSchema)),
+          queryKey: innerKey,
+          ...innerDefKey,
+        });
+      } else {
+        const innerDefKey = { ...(value.queryKey ? { _def: key } : undefined) };
+        const innerKey = [...key, ...(value.queryKey ?? [])] as const;
+
+        yieldValue = omitPrototype({
           queryKey: innerKey,
           ...innerDefKey,
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ type NullableQueryKeyRecord = Record<'queryKey', readonly [ValidValue] | null>;
 type QueryKeyRecord = Record<'queryKey', readonly [ValidValue]>;
 
 type KeySchemaWithContextualQueries = NullableQueryKeyRecord & {
-  context: FactorySchema;
+  contextQueries: FactorySchema;
 };
 
 type QueryFactorySchema = NullableQueryKeyRecord & {
@@ -27,11 +27,11 @@ type QueryFactorySchema = NullableQueryKeyRecord & {
 
 type QueryFactoryWithContextualQueriesSchema = NullableQueryKeyRecord & {
   queryFn: QueryFunction;
-  context: FactorySchema;
+  contextQueries: FactorySchema;
 };
 
 type DynamicKeySchemaWithContextualQueries = QueryKeyRecord & {
-  context: FactorySchema;
+  contextQueries: FactorySchema;
 };
 
 type DynamicQueryFactorySchema = QueryKeyRecord & {
@@ -40,7 +40,7 @@ type DynamicQueryFactorySchema = QueryKeyRecord & {
 
 type DynamicQueryFactoryWithContextualQueriesSchema = QueryKeyRecord & {
   queryFn: QueryFunction;
-  context: FactorySchema;
+  contextQueries: FactorySchema;
 };
 
 type FactoryProperty =
@@ -95,25 +95,25 @@ type FactoryWithContextualQueriesOutput<
   BaseKey extends AnyMutableOrReadonlyArray,
   Schema extends KeySchemaWithContextualQueries | DynamicKeySchemaWithContextualQueries,
   SchemaQueryKey extends Schema['queryKey'] = Schema['queryKey'],
-  ContextFactory extends Schema['context'] = Schema['context'],
+  ContextQueries extends Schema['contextQueries'] = Schema['contextQueries'],
   ComposedKey extends AnyMutableOrReadonlyArray = ComposeQueryKey<BaseKey, ExtractNullableKey<SchemaQueryKey>>,
 > = SchemaQueryKey extends null
   ? Omit<QueryOptions<ComposedKey, QueryFunction>, 'queryFn'> & {
       _ctx: {
-        [P in keyof ContextFactory]: ContextFactory[P] extends DynamicKey
-          ? DynamicFactoryOutput<[...ComposedKey, P], ContextFactory[P]>
-          : ContextFactory[P] extends FactoryProperty
-          ? StaticFactoryOutput<[...ComposedKey, P], ContextFactory[P]>
+        [P in keyof ContextQueries]: ContextQueries[P] extends DynamicKey
+          ? DynamicFactoryOutput<[...ComposedKey, P], ContextQueries[P]>
+          : ContextQueries[P] extends FactoryProperty
+          ? StaticFactoryOutput<[...ComposedKey, P], ContextQueries[P]>
           : never;
       };
     }
   : Omit<QueryOptions<ComposedKey, QueryFunction>, 'queryFn'> &
       DefinitionKey<BaseKey> & {
         _ctx: {
-          [P in keyof ContextFactory]: ContextFactory[P] extends DynamicKey
-            ? DynamicFactoryOutput<[...ComposedKey, P], ContextFactory[P]>
-            : ContextFactory[P] extends FactoryProperty
-            ? StaticFactoryOutput<[...ComposedKey, P], ContextFactory[P]>
+          [P in keyof ContextQueries]: ContextQueries[P] extends DynamicKey
+            ? DynamicFactoryOutput<[...ComposedKey, P], ContextQueries[P]>
+            : ContextQueries[P] extends FactoryProperty
+            ? StaticFactoryOutput<[...ComposedKey, P], ContextQueries[P]>
             : never;
         };
       };
@@ -142,25 +142,25 @@ type FactoryQueryOptionsWithContextualQueriesOutput<
   Schema extends QueryFactoryWithContextualQueriesSchema | DynamicQueryFactoryWithContextualQueriesSchema,
   SchemaQueryKey extends Schema['queryKey'] = Schema['queryKey'],
   QueryFn extends Schema['queryFn'] = Schema['queryFn'],
-  ContextFactory extends Schema['context'] = Schema['context'],
+  ContextQueries extends Schema['contextQueries'] = Schema['contextQueries'],
   Key extends AnyMutableOrReadonlyArray = ComposeQueryKey<BaseKey, ExtractNullableKey<SchemaQueryKey>>,
 > = SchemaQueryKey extends null
   ? QueryOptions<Key, QueryFn> & {
       _ctx: {
-        [P in keyof ContextFactory]: ContextFactory[P] extends DynamicKey
-          ? DynamicFactoryOutput<[...Key, P], ContextFactory[P]>
-          : ContextFactory[P] extends FactoryProperty
-          ? StaticFactoryOutput<[...Key, P], ContextFactory[P]>
+        [P in keyof ContextQueries]: ContextQueries[P] extends DynamicKey
+          ? DynamicFactoryOutput<[...Key, P], ContextQueries[P]>
+          : ContextQueries[P] extends FactoryProperty
+          ? StaticFactoryOutput<[...Key, P], ContextQueries[P]>
           : never;
       };
     }
   : DefinitionKey<BaseKey> &
       QueryOptions<Key, QueryFn> & {
         _ctx: {
-          [P in keyof ContextFactory]: ContextFactory[P] extends DynamicKey
-            ? DynamicFactoryOutput<[...Key, P], ContextFactory[P]>
-            : ContextFactory[P] extends FactoryProperty
-            ? StaticFactoryOutput<[...Key, P], ContextFactory[P]>
+          [P in keyof ContextQueries]: ContextQueries[P] extends DynamicKey
+            ? DynamicFactoryOutput<[...Key, P], ContextQueries[P]>
+            : ContextQueries[P] extends FactoryProperty
+            ? StaticFactoryOutput<[...Key, P], ContextQueries[P]>
             : never;
         };
       };


### PR DESCRIPTION
This PR adds the ability to declare a query option object for a key with only `queryKey` as a property