### PR TITLE
feat: update `infer` type helpers to work with new API

### DIFF
--- a/.changeset/olive-zoos-wash.md
+++ b/.changeset/olive-zoos-wash.md
@@ -120,3 +120,13 @@ export const todosKeys = createQueryKeys('todos', {
 
 + useQuery(todosKeys.list(filters));
 ```
+
+#### Helper types to infer query keys in the store reflect the new output
+The helper types to infer query keys in the created store reflect the new output, to account for all possible use cases:
+
+```diff
+type TodosKeys = inferQueryKeys<typeof todosKeys>;
+
+- type SingleTodoQueryKey = TodosKeys['todo'];
++ type SingleTodoQueryKey = TodosKeys['todo']['queryKey'];
+```

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 <p align="center">
-  <a href="https://github.com/lukemorales/query-key-factory"><img src="https://images.emojiterra.com/mozilla/512px/1f3ed.png" alt="Factory emoji" height="130"/ target="\_parent"></a>
+  <a href="https://github.com/lukemorales/query-key-factory" target="\_parent"><img src="https://images.emojiterra.com/mozilla/512px/1f3ed.png" alt="Factory emoji" height="130"></a>
 </p>
 
 <h1 align="center">Query Key Factory</h1>
 
 <p align="center">
-  <a href="https://github.com/lukemorales/query-key-factory/actions/workflows/tests.yml"><img src="https://github.com/lukemorales/query-key-factory/actions/workflows/tests.yml/badge.svg?branch=main" alt="Latest build" target="\_parent"></a>
-  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory"><img src="https://badgen.net/npm/v/@lukemorales/query-key-factory" alt="Latest published version" target="\_parent"></a>
-  <a href="https://bundlephobia.com/package/@lukemorales/query-key-factory@latest"><img src="https://badgen.net/bundlephobia/minzip/@lukemorales/query-key-factory" alt="Bundlephobia" target="\_parent"></a>
-  <a href="https://bundlephobia.com/package/@lukemorales/query-key-factory@latest"><img src="https://badgen.net/bundlephobia/tree-shaking/@lukemorales/query-key-factory" alt="Tree shaking available" target="\_parent"></a>
-  <a href="https://github.com/lukemorales/query-key-factory"><img src="https://badgen.net/npm/types/@lukemorales/query-key-factory" alt="Types included" target="\_parent"></a>
-  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory"><img src="https://badgen.net/npm/license/@lukemorales/query-key-factory" alt="License" target="\_parent"></a>
-  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory"><img src="https://badgen.net/npm/dt/@lukemorales/query-key-factory" alt="Number of downloads" target="\_parent"></a>
-  <a href="https://github.com/lukemorales/query-key-factory"><img src="https://img.shields.io/github/stars/lukemorales/query-key-factory.svg?style=social&amp;label=Star" alt="GitHub Stars" target="\_parent"></a>
+  <a href="https://github.com/lukemorales/query-key-factory/actions/workflows/tests.yml" target="\_parent"><img src="https://github.com/lukemorales/query-key-factory/actions/workflows/tests.yml/badge.svg?branch=main" alt="Latest build"></a>
+  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory" target="\_parent"><img src="https://badgen.net/npm/v/@lukemorales/query-key-factory" alt="Latest published version"></a>
+  <a href="https://bundlephobia.com/package/@lukemorales/query-key-factory@latest" target="\_parent"><img src="https://badgen.net/bundlephobia/minzip/@lukemorales/query-key-factory" alt="Bundlephobia"></a>
+  <a href="https://bundlephobia.com/package/@lukemorales/query-key-factory@latest" target="\_parent"><img src="https://badgen.net/bundlephobia/tree-shaking/@lukemorales/query-key-factory" alt="Tree shaking available"></a>
+  <a href="https://github.com/lukemorales/query-key-factory" target="\_parent"><img src="https://badgen.net/npm/types/@lukemorales/query-key-factory" alt="Types included"></a>
+  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory" target="\_parent"><img src="https://badgen.net/npm/license/@lukemorales/query-key-factory" alt="License"></a>
+  <a href="https://www.npmjs.com/package/@lukemorales/query-key-factory" target="\_parent"><img src="https://badgen.net/npm/dt/@lukemorales/query-key-factory" alt="Number of downloads"></a>
+  <a href="https://github.com/lukemorales/query-key-factory" target="\_parent"><img src="https://img.shields.io/github/stars/lukemorales/query-key-factory.svg?style=social&amp;label=Star" alt="GitHub Stars"></a>
 </p>
 
 <p align="center">
-  <strong>Typesafe query key management for <a href="https://tanstack.com/query" alt="Tanstack Query" target="\_parent">@tanstack/query</a> with auto-completion features.</strong>
+  <strong>Typesafe query key management for <a href="https://tanstack.com/query" target="\_parent">@tanstack/query</a> with auto-completion features.</strong>
 </p>
 
 <p align="center">
@@ -38,12 +38,31 @@ Start by defining the query keys for the features of your app:
 import { createQueryKeyStore } from "@lukemorales/query-key-factory";
 
 // if your prefer to declare everything in one file
-export const queryKeys = createQueryKeyStore({
-  users: null,
+export const queries = createQueryKeyStore({
+  users: {
+    all: null,
+    detail: (userId: string) => ({
+      queryKey: [userId],
+      queryFn: () => api.getUser(userId),
+    }),
+  },
   todos: {
-    list: (filters: TodoFilters) => ({ filters }),
-    search: (query: string, limit = 15) => [query, limit],
-    todo: (todoId: string) => todoId,
+    detail: (todoId: string) => [todoId],
+    list: (filters: TodoFilters) => ({
+      queryKey: [{ filters }],
+      queryFn: (ctx) => api.getTodos({ filters, page: ctx.pageParam }),
+      contextQueries: {
+        search: (query: string, limit = 15) => ({
+          queryKey: [query, limit],
+          queryFn: (ctx) => api.getSearchTodos({
+            page: ctx.pageParam,
+            filters,
+            limit,
+            query,
+          }),
+        }),
+      },
+    }),
   },
 });
 ```
@@ -53,38 +72,65 @@ export const queryKeys = createQueryKeyStore({
 import { createQueryKeys, mergeQueryKeys } from "@lukemorales/query-key-factory";
 
 // queries/users.ts
-export const usersKeys = createQueryKeys('users');
+export const users = createQueryKeys('users', {
+  all: null,
+  detail: (userId: string) => ({
+    queryKey: [userId],
+    queryFn: () => api.getUser(userId),
+  }),
+});
 
 // queries/todos.ts
-export const todosKeys = createQueryKeys('todos', {
-  list: (filters: TodoFilters) => ({ filters }),
-  search: (query: string, limit = 15) => [query, limit],
-  todo: (todoId: string) => todoId,
+export const todos = createQueryKeys('todos', {
+  detail: (todoId: string) => [todoId],
+  list: (filters: TodoFilters) => ({
+    queryKey: [{ filters }],
+    queryFn: (ctx) => api.getTodos({ filters, page: ctx.pageParam }),
+    contextQueries: {
+      search: (query: string, limit = 15) => ({
+        queryKey: [query, limit],
+        queryFn: (ctx) => api.getSearchTodos({
+          page: ctx.pageParam,
+          filters,
+          limit,
+          query,
+        }),
+      }),
+    },
+  }),
 });
 
 // queries/index.ts
-export const queryKeys = mergeQueryKeys(usersKeys, todosKeys);
+export const queries = mergeQueryKeys(users, todos);
 ```
 
-Use throughout your codebase as the single source for writing the query keys for your cache management:
+Use throughout your codebase as the single source for writing the query keys, or even the complete queries for your cache management:
 
 ```ts
-import { queryKeys } from '../queries';
+import { queries } from '../queries';
 
 export function useUsers() {
-  return useQuery(queryKeys.users._def, fetchUsers);
+  return useQuery({
+    ...queries.users.all,
+    queryFn: () => api.getUsers(),
+  });
+};
+
+export function useUserDetail(id: string) {
+  return useQuery(queries.users.detail(id));
 };
 ```
 
 ```ts
-import { queryKeys } from '../queries';
+import { queries } from '../queries';
 
 export function useTodos(filters: TodoFilters) {
-  return useQuery(queryKeys.todos.list(filters), fetchTodos);
+  return useQuery(queries.todos.list(filters));
 };
 
-export function useSearchTodos(query: string, limit = 15) {
-  return useQuery(queryKeys.todos.search(query, limit), fetchSearchTodos, {
+export function useSearchTodos(filters: TodoFilters, query: string, limit = 15) {
+  return useQuery({
+    ...queries.todos.list(filters)._ctx.search(query, limit),
     enabled: Boolean(query),
   });
 };
@@ -94,11 +140,11 @@ export function useUpdateTodo() {
 
   return useMutation(updateTodo, {
     onSuccess(newTodo) {
-      queryClient.setQueryData(queryKeys.todos.todo(newTodo.id), newTodo);
+      queryClient.setQueryData(queries.todos.detail(newTodo.id).queryKey, newTodo);
 
       // invalidate all the list queries
       queryClient.invalidateQueries({
-        queryKey: queryKeys.todos.list._def,
+        queryKey: queries.todos.list._def,
         refetchActive: false,
       });
     },
@@ -108,36 +154,98 @@ export function useUpdateTodo() {
 <br />
 
 ## 📝 Features
+
 ### Standardized keys
-All keys generated follow the @tanstack/query standard of being an [array at top level](https://tanstack.com/query/v4/docs/guides/query-keys), including [keys with serializable objects](https://tanstack.com/query/v4/docs/guides/query-keys#array-keys-with-variables):
+All keys generated follow the @tanstack/query convention of being an [array at top level](https://tanstack.com/query/v4/docs/guides/query-keys), including [keys with serializable objects](https://tanstack.com/query/v4/docs/guides/query-keys#array-keys-with-variables):
 
 ```ts
-export const todosKeys = createQueryKeys('todos', {
-  list: (filters: TodoFilters) => ({ filters }),
-  search: (query: string, limit = 15) => [query, limit],
-  todo: (todoId: string) => todoId,
+export const todos = createQueryKeys('todos', {
+  detail: (todoId: string) => [todoId],
+  list: (filters: TodoFilters) => ({
+    queryKey: [{ filters }],
+  }),
 });
 
 // => createQueryKeys output:
 // {
 //   _def: ['todos'],
-//   list: (filters: TodoFilters) => ['todos', 'list', { filters }],
-//   search: (query: string, limit = 15) => ['todos', 'search', query, limit],
-//   todo: (todoId: string) => ['todos', 'todo', todoId],
+//   detail: (todoId: string) => {
+//     queryKey: ['todos', 'todo', todoId],
+//   },
+//   list: (filters: TodoFilters) => {
+//     queryKey: ['todos', 'list', { filters }],
+//   },
 // }
+```
+
+### Generate the query options you need to run `useQuery`
+Declare your `queryKey` and your `queryFn` together, and have easy access to everything you need to run a query:
+
+```ts
+export const users = createQueryKeys('users', {
+  detail: (userId: string) => ({
+    queryKey: [userId],
+    queryFn: () => api.getUser(userId),
+  }),
+});
+
+// => createQueryKeys output:
+// {
+//   _def: ['users'],
+//   detail: (userId: string) => {
+//     queryKey: ['users', 'detail', userId],
+//     queryFn: (ctx: QueryFunctionContext) => api.getUser(userId),
+//   },
+// }
+
+export function useUserDetail(id: string) {
+  return useQuery(users.detail(id));
+};
+```
+
+### Generate contextual queries
+Declare queries that are dependent or related to a parent context (e.g.: all likes from a user):
+
+```ts
+export const users = createQueryKeys('users', {
+  detail: (userId: string) => ({
+    queryKey: [userId],
+    queryFn: () => api.getUser(userId),
+    contextQueries: {
+      likes: {
+        queryKey: null,
+        queryFn: () => api.getUserLikes(userId),
+      },
+    },
+  }),
+});
+
+// => createQueryKeys output:
+// {
+//   _def: ['users'],
+//   detail: (userId: string) => {
+//     queryKey: ['users', 'detail', userId],
+//     queryFn: (ctx: QueryFunctionContext) => api.getUser(userId),
+//     _ctx: {
+//       likes: {
+//         queryKey: ['users', 'detail, userId, 'likes'],
+//         queryFn: (ctx: QueryFunctionContext) => api.getUserLikes(userId),
+//       },
+//     },
+//   },
+// }
+
+export function useUserLikes(userId: string) {
+  return useQuery(users.detail(userId)._ctx.likes);
+};
 ```
 
 ### Access to serializable keys scope definition
 Easy way to access the serializable key scope and invalidate all cache for that context:
+
 ```ts
-todosKeys.list({ status: 'completed' }) // => ['todos', 'list', { status: 'completed' }]
-todosKeys.list._def; // => ['todos', 'list']
-
-todosKeys.search('tanstack query', 15); // => ['todos', 'search', 'tanstack query', 15]
-todosKeys.search._def; // => ['todos', 'search']
-
-todosKeys.todo('todo-id'); // => ['todos', 'todo', 'todo-id']
-todosKeys.todo._def; // => ['todos', 'todo']
+users.detail({ status: 'completed' }).queryKey; // => ['users', 'detail', userId]
+users.detail._def; // => ['users', 'detail']
 ```
 
 ### Create a single point of access for all your query keys
@@ -145,27 +253,22 @@ todosKeys.todo._def; // => ['todos', 'todo']
 #### Declare your query keys store in a single file
 Just one place to edit and maintain your store:
 ```ts
-export const queryKeys = createQueryKeyStore({
-  users: null,
+export const queries = createQueryKeyStore({
+  users: {
+    all: null,
+    detail: (userId: string) => ({
+      queryKey: [userId],
+      queryFn: () => api.getUser(userId),
+    }),
+  },
   todos: {
-    list: (filters: TodoFilters) => ({ filters }),
-    search: (query: string, limit = 15) => [query, limit],
-    todo: (todoId: string) => todoId,
+    detail: (todoId: string) => [todoId],
+    list: (filters: TodoFilters) => ({
+      queryKey: [{ filters }],
+      queryFn: (ctx) => api.getTodos({ filters, page: ctx.pageParam }),
+    }),
   },
 });
-
-// => createQueryKeyStore output:
-// {
-//   users: {
-//     _def: ['users'],
-//   },
-//   todos: {
-//     _def: ['todos'],
-//     list: (filters: TodoFilters) => ['todos', 'list', { filters }],
-//     search: (query: string, limit = 15) => ['todos', 'search', query, limit],
-//     todo: (todoId: string) => ['todos', 'todo', todoId],
-//   },
-// };
 ```
 
 #### Declare your query keys by feature
@@ -173,93 +276,65 @@ Have fine-grained control over your features' keys and merge them into a single 
 
 ```ts
 // queries/users.ts
-const usersKeys = createQueryKeys('users');
+export const users = createQueryKeys('users', {
+  all: null,
+  detail: (userId: string) => ({
+    queryKey: [userId],
+    queryFn: () => api.getUser(userId),
+  }),
+});
 
 // queries/todos.ts
-const todosKeys = createQueryKeys('todos', {
-  list: (filters: TodoFilters) => ({ filters }),
-  search: (query: string, limit = 15) => [query, limit],
-  todo: (todoId: string) => todoId,
+export const todos = createQueryKeys('todos', {
+  detail: (todoId: string) => [todoId],
+  list: (filters: TodoFilters) => ({
+    queryKey: [{ filters }],
+    queryFn: (ctx) => api.getTodos({ filters, page: ctx.pageParam }),
+  }),
 });
 
 // queries/index.ts
-export const queryKeys = mergeQueryKeys(usersKeys, todosKeys);
-
-// => mergeQueryKeys output:
-// {
-//   users: {
-//     _def: ['users'],
-//   },
-//   todos: {
-//     _def: ['todos'],
-//     list: (filters: TodoFilters) => ['todos', 'list', { filters }],
-//     search: (query: string, limit = 15) => ['todos', 'search', query, limit],
-//     todo: (todoId: string) => ['todos', 'todo', todoId],
-//   },
-// };
+export const queries = mergeQueryKeys(users, todos);
 ```
 
 ### Type safety and smart autocomplete
-Typescript is a first class citizen of the Query Key Factory lib, providing easy of use and autocomplete for all query keys available and their outputs. Don't remember if a key is serializable or the shape of a key? Just mouseover and your IDE will show you all information you need to know.
+Typescript is a first class citizen of Query Key Factory, providing easy of use and autocomplete for all query keys available and their outputs. Don't remember if a key is serializable or the shape of a key? Just let your IDE show you all information you need.
 
 #### Infer the type of the store's query keys
 ```ts
 import { createQueryKeyStore, inferQueryKeyStore } from "@lukemorales/query-key-factory";
 
-export const queryKeys = createQueryKeyStore({
-  users: null,
-  todos: {
-    list: (filters: TodoFilters) => ({ filters }),
-    search: (query: string, limit = 15) => [query, limit],
-    todo: (todoId: string) => todoId,
-  },
+export const queries = createQueryKeyStore({
+  /* ... */
 });
 
-export type QueryKeys = inferQueryKeyStore<typeof queryKeys>;
-
-// => QueryKeys type:
-// {
-//   users: {
-//     _def: readonly ['users'];
-//   };
-//   todos: {
-//     _def: readonly ['todos'];
-//     list: readonly ['todos', 'list', { filters: TodoFilters }];
-//     search: readonly ['todos', 'search', string, number];
-//     todo: readonly ['todos', 'todo', string];
-//   };
-// }
+export type QueryKeys = inferQueryKeyStore<typeof queries>;
 ```
 ```ts
-import { createQueryKeys, inferQueryKeyStore } from "@lukemorales/query-key-factory";
-
-// queries/users.ts
-const usersKeys = createQueryKeys('users');
-
-// queries/todos.ts
-const todosKeys = createQueryKeys('todos', {
-  list: (filters: TodoFilters) => ({ filters }),
-  search: (query: string, limit = 15) => [query, limit],
-  todo: (todoId: string) => todoId,
-});
-
 // queries/index.ts
-export const queryKeys = mergeQueryKeys(usersKeys, todosKeys);
+import { mergeQueryKeys, inferQueryKeyStore } from "@lukemorales/query-key-factory";
 
-export type QueryKeys = inferQueryKeyStore<typeof queryKeys>;
+import { users } from './users';
+import { todos } from './todos';
+
+export const queries = mergeQueryKeys(users, todos);
+
+export type QueryKeys = inferQueryKeyStore<typeof queries>;
 ```
 
 #### Infer the type of a feature's query keys
 ```ts
 import { createQueryKeys, inferQueryKeys } from "@lukemorales/query-key-factory";
 
-export const todosKeys = createQueryKeys('todos', {
-  list: (filters: TodoFilters) => ({ filters }),
-  search: (query: string, limit = 15) => [query, limit],
-  todo: (todoId: string) => todoId,
+export const todos = createQueryKeys('todos', {
+  detail: (todoId: string) => [todoId],
+  list: (filters: TodoFilters) => ({
+    queryKey: [{ filters }],
+    queryFn: (ctx) => api.getTodos({ filters, page: ctx.pageParam }),
+  }),
 });
 
-export type TodosKeys = inferQueryKeys<typeof todosKeys>;
+export type TodosKeys = inferQueryKeys<typeof todos>;
 ```
 
 #### Type your QueryFunctionContext with ease
@@ -267,19 +342,21 @@ Get accurate types of your query keys passed to the `queryFn` context:
 
 ```ts
 import type { QueryKeys } from "../queries";
-import type { TodosKeys } from "../queries/todos";
+// import type { TodosKeys } from "../queries/todos";
 
-type TodosListQueryKey = QueryKeys['todos']['list'] | TodosKeys['list'];
+type TodosList = QueryKeys['todos']['list'];
+// type TodosList = TodosKeys['list'];
 
-const fetchTodos = async (ctx: QueryFunctionContext<TodosListQueryKey>) => {
-  const [, , { filters }] = ctx.queryKey; // readonly ['todos', 'list', { filters }]
+const fetchTodos = async (ctx: QueryFunctionContext<TodosList['queryKey']>) => {
+  const [, , { filters }] = ctx.queryKey;
 
-  const search = new URLSearchParams(filters);
-
-  return fetch(`${BASE_URL}/todos?${search.toString()}`).then(data => data.json());
+  return api.getTodos({ filters, page: ctx.pageParam });
 }
 
 export function useTodos(filters: TodoFilters) {
-  return useQuery(queryKeys.todos.list(filters), fetchTodos);
+  return useQuery({
+    ...queries.todos.list(filters),
+    queryFn: fetchTodos,
+  });
 };
 ```

--- a/src/create-query-key-store.spec.ts
+++ b/src/create-query-key-store.spec.ts
@@ -15,7 +15,7 @@ describe('createQueryKeyStore', () => {
         detail: (userId: string) => ({
           queryKey: [userId],
           queryFn: () => Promise.resolve({ id: userId }),
-          context: {
+          contextQueries: {
             settings: null,
           },
         }),
@@ -23,7 +23,7 @@ describe('createQueryKeyStore', () => {
       todos: {
         detail: (todoId: string) => [todoId],
         list: (filters: Filters) => [{ filters }],
-        search: (query: string, limit = 15) => [query, limit],
+        search: (query: string, limit: number) => [query, limit],
       },
     });
 
@@ -48,7 +48,7 @@ describe('createQueryKeyStore', () => {
       },
     });
 
-    expect<inferQueryKeyStore<typeof store>>(store).toHaveType<{
+    expect(store).toHaveType<{
       users: {
         _def: readonly ['users'];
         me: {
@@ -86,6 +86,39 @@ describe('createQueryKeyStore', () => {
         ) => {
           queryKey: readonly ['todos', 'search', string, number];
         });
+      };
+    }>();
+
+    expect({} as inferQueryKeyStore<typeof store>).toHaveStrictType<{
+      users: {
+        _def: readonly ['users'];
+        me: {
+          queryKey: readonly ['users', 'me'];
+        };
+        detail: {
+          _def: readonly ['users', 'detail'];
+          queryKey: readonly ['users', 'detail', string];
+          _ctx: {
+            settings: {
+              queryKey: readonly ['users', 'detail', string, 'settings'];
+            };
+          };
+        };
+      };
+      todos: {
+        _def: readonly ['todos'];
+        detail: {
+          _def: readonly ['todos', 'detail'];
+          queryKey: readonly ['todos', 'detail', string];
+        };
+        list: {
+          _def: readonly ['todos', 'list'];
+          queryKey: readonly ['todos', 'list', { filters: Filters }];
+        };
+        search: {
+          _def: readonly ['todos', 'search'];
+          queryKey: readonly ['todos', 'search', string, number];
+        };
       };
     }>();
   });

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -1,5 +1,6 @@
 import { createQueryKeys } from './create-query-keys';
 import { QueryFunction } from './query-context.types';
+import { inferQueryKeys } from './types';
 
 describe('createQueryKeys', () => {
   describe('when called only with the key argument', () => {
@@ -14,6 +15,10 @@ describe('createQueryKeys', () => {
       });
 
       expect(sut).toHaveType<{ _def: readonly ['test'] }>();
+
+      expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+        _def: readonly ['test'];
+      }>();
     });
 
     it('creates the "_def" query key as an array', () => {
@@ -63,6 +68,13 @@ describe('createQueryKeys', () => {
           });
 
           expect(sut.prop).toHaveType<{ queryKey: readonly ['test', 'prop'] }>();
+
+          expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+            _def: readonly ['test'];
+            prop: {
+              queryKey: readonly ['test', 'prop'];
+            };
+          }>();
         });
       });
 
@@ -85,6 +97,14 @@ describe('createQueryKeys', () => {
           expect(sut.prop).toHaveType<{
             _def: readonly ['test', 'prop'];
             queryKey: readonly ['test', 'prop', string];
+          }>();
+
+          expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+            _def: readonly ['test'];
+            prop: {
+              _def: readonly ['test', 'prop'];
+              queryKey: readonly ['test', 'prop', string];
+            };
           }>();
         });
       });
@@ -370,12 +390,18 @@ describe('createQueryKeys', () => {
         });
 
         expect(sut.prop).toHaveType<
-          {
-            _def: readonly ['test', 'prop'];
-          } & ((value: string) => {
+          { _def: readonly ['test', 'prop'] } & ((value: string) => {
             queryKey: readonly ['test', 'prop', string];
           })
         >();
+
+        expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+          _def: readonly ['test'];
+          prop: {
+            _def: readonly ['test', 'prop'];
+            queryKey: readonly ['test', 'prop', string];
+          };
+        }>();
       });
 
       describe('when the function returns a tuple', () => {
@@ -391,12 +417,18 @@ describe('createQueryKeys', () => {
           });
 
           expect(sut.prop).toHaveType<
-            {
-              _def: readonly ['test', 'prop'];
-            } & ((value: string) => {
+            { _def: readonly ['test', 'prop'] } & ((value: string) => {
               queryKey: readonly ['test', 'prop', string];
             })
           >();
+
+          expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+            _def: readonly ['test'];
+            prop: {
+              _def: readonly ['test', 'prop'];
+              queryKey: readonly ['test', 'prop', string];
+            };
+          }>();
         });
       });
 
@@ -415,12 +447,18 @@ describe('createQueryKeys', () => {
             });
 
             expect(sut.prop).toHaveStrictType<
-              {
-                _def: readonly ['test', 'prop'];
-              } & ((value: string) => {
+              { _def: readonly ['test', 'prop'] } & ((value: string) => {
                 queryKey: readonly ['test', 'prop', string];
               })
             >();
+
+            expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+              _def: readonly ['test'];
+              prop: {
+                _def: readonly ['test', 'prop'];
+                queryKey: readonly ['test', 'prop', string];
+              };
+            }>();
           });
         });
 
@@ -440,13 +478,19 @@ describe('createQueryKeys', () => {
             });
 
             expect(sut.prop).toHaveType<
-              {
-                _def: readonly ['test', 'prop'];
-              } & ((value: string) => {
+              { _def: readonly ['test', 'prop'] } & ((value: string) => {
                 queryKey: readonly ['test', 'prop', string];
                 queryFn: QueryFunction<boolean, readonly ['test', 'prop', string]>;
               })
             >();
+
+            expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+              _def: readonly ['test'];
+              prop: {
+                _def: readonly ['test', 'prop'];
+                queryKey: readonly ['test', 'prop', string];
+              };
+            }>();
           });
         });
 
@@ -473,9 +517,7 @@ describe('createQueryKeys', () => {
             });
 
             expect(sut.prop).toHaveType<
-              {
-                _def: readonly ['test', 'prop'];
-              } & ((value: string) => {
+              { _def: readonly ['test', 'prop'] } & ((value: string) => {
                 _ctx: {
                   'context-prop': {
                     queryKey: readonly ['test', 'prop', string, 'context-prop'];
@@ -484,6 +526,19 @@ describe('createQueryKeys', () => {
                 queryKey: readonly ['test', 'prop', string];
               })
             >();
+
+            expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+              _def: readonly ['test'];
+              prop: {
+                _def: readonly ['test', 'prop'];
+                _ctx: {
+                  'context-prop': {
+                    queryKey: readonly ['test', 'prop', string, 'context-prop'];
+                  };
+                };
+                queryKey: readonly ['test', 'prop', string];
+              };
+            }>();
           });
         });
 
@@ -512,9 +567,7 @@ describe('createQueryKeys', () => {
             });
 
             expect(sut.prop).toHaveType<
-              {
-                _def: readonly ['test', 'prop'];
-              } & ((value: string) => {
+              { _def: readonly ['test', 'prop'] } & ((value: string) => {
                 _ctx: {
                   'context-prop': {
                     queryKey: readonly ['test', 'prop', string, 'context-prop'];
@@ -524,6 +577,19 @@ describe('createQueryKeys', () => {
                 queryFn: QueryFunction<boolean, readonly ['test', 'prop', string]>;
               })
             >();
+
+            expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+              _def: readonly ['test'];
+              prop: {
+                _def: readonly ['test', 'prop'];
+                _ctx: {
+                  'context-prop': {
+                    queryKey: readonly ['test', 'prop', string, 'context-prop'];
+                  };
+                };
+                queryKey: readonly ['test', 'prop', string];
+              };
+            }>();
           });
         });
       });
@@ -587,14 +653,35 @@ describe('createQueryKeys |> extrapolating "contextQueries" nesting', () => {
             _def: readonly ['test', 'prop', 'nested2'];
             queryKey: readonly ['test', 'prop', 'nested2', string];
           };
-          nested3: {
-            _def: readonly ['test', 'prop', 'nested3'];
-          } & ((value: string) => {
+          nested3: { _def: readonly ['test', 'prop', 'nested3'] } & ((value: string) => {
             queryKey: readonly ['test', 'prop', 'nested3', string];
             _ctx: {
               nested4: { queryKey: readonly ['test', 'prop', 'nested3', string, 'nested4'] };
             };
           });
+        };
+      }>();
+
+      expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+        _def: readonly ['test'];
+        prop: {
+          queryKey: readonly ['test', 'prop'];
+          _ctx: {
+            nested1: { queryKey: readonly ['test', 'prop', 'nested1'] };
+            nested2: {
+              _def: readonly ['test', 'prop', 'nested2'];
+              queryKey: readonly ['test', 'prop', 'nested2', string];
+            };
+            nested3: {
+              _def: readonly ['test', 'prop', 'nested3'];
+              queryKey: readonly ['test', 'prop', 'nested3', string];
+              _ctx: {
+                nested4: {
+                  queryKey: readonly ['test', 'prop', 'nested3', string, 'nested4'];
+                };
+              };
+            };
+          };
         };
       }>();
     });
@@ -651,9 +738,7 @@ describe('createQueryKeys |> extrapolating "contextQueries" nesting', () => {
               _def: readonly ['test', 'prop', string, 'nested2'];
               queryKey: readonly ['test', 'prop', string, 'nested2', string];
             };
-            nested3: {
-              _def: readonly ['test', 'prop', string, 'nested3'];
-            } & ((nestedValue: string) => {
+            nested3: { _def: readonly ['test', 'prop', string, 'nested3'] } & ((nestedValue: string) => {
               queryKey: readonly ['test', 'prop', string, 'nested3', string];
               _ctx: {
                 nested4: { queryKey: readonly ['test', 'prop', string, 'nested3', string, 'nested4'] };
@@ -662,6 +747,30 @@ describe('createQueryKeys |> extrapolating "contextQueries" nesting', () => {
           };
         })
       >();
+
+      expect({} as inferQueryKeys<typeof sut>).toHaveStrictType<{
+        _def: readonly ['test'];
+        prop: {
+          _def: readonly ['test', 'prop'];
+          queryKey: readonly ['test', 'prop', string];
+          _ctx: {
+            nested1: { queryKey: readonly ['test', 'prop', string, 'nested1'] };
+            nested2: {
+              _def: readonly ['test', 'prop', string, 'nested2'];
+              queryKey: readonly ['test', 'prop', string, 'nested2', string];
+            };
+            nested3: {
+              _def: readonly ['test', 'prop', string, 'nested3'];
+              queryKey: readonly ['test', 'prop', string, 'nested3', string];
+              _ctx: {
+                nested4: {
+                  queryKey: readonly ['test', 'prop', string, 'nested3', string, 'nested4'];
+                };
+              };
+            };
+          };
+        };
+      }>();
     });
   });
 });

--- a/src/merge-query-keys.spec.ts
+++ b/src/merge-query-keys.spec.ts
@@ -15,7 +15,7 @@ describe('mergeQueryKeys', () => {
       detail: (userId: string) => ({
         queryKey: [userId],
         queryFn: () => Promise.resolve({ id: userId }),
-        context: {
+        contextQueries: {
           settings: null,
         },
       }),
@@ -23,7 +23,7 @@ describe('mergeQueryKeys', () => {
     const todosKeys = createQueryKeys('todos', {
       detail: (todoId: string) => [todoId],
       list: (filters: Filters) => [{ filters }],
-      search: (query: string, limit = 15) => [query, limit],
+      search: (query: string, limit: number) => [query, limit],
     });
 
     return { usersKeys, todosKeys };
@@ -42,7 +42,7 @@ describe('mergeQueryKeys', () => {
       todos: todosKeys,
     });
 
-    expect<inferQueryKeyStore<typeof store>>(store).toHaveType<{
+    expect(store).toHaveType<{
       users: {
         _def: readonly ['users'];
         me: {
@@ -80,6 +80,39 @@ describe('mergeQueryKeys', () => {
         ) => {
           queryKey: readonly ['todos', 'search', string, number];
         });
+      };
+    }>();
+
+    expect({} as inferQueryKeyStore<typeof store>).toHaveStrictType<{
+      users: {
+        _def: readonly ['users'];
+        me: {
+          queryKey: readonly ['users', 'me'];
+        };
+        detail: {
+          _def: readonly ['users', 'detail'];
+          _ctx: {
+            settings: {
+              queryKey: readonly ['users', 'detail', string, 'settings'];
+            };
+          };
+          queryKey: readonly ['users', 'detail', string];
+        };
+      };
+      todos: {
+        _def: readonly ['todos'];
+        detail: {
+          _def: readonly ['todos', 'detail'];
+          queryKey: readonly ['todos', 'detail', string];
+        };
+        list: {
+          _def: readonly ['todos', 'list'];
+          queryKey: readonly ['todos', 'list', { filters: Filters }];
+        };
+        search: {
+          _def: readonly ['todos', 'search'];
+          queryKey: readonly ['todos', 'search', string, number];
+        };
       };
     }>();
   });


### PR DESCRIPTION
This PR updates the `infer` type helpers to work with the new API