### PR TITLE
fix: repair conflicting types

### DIFF
--- a/.changeset/fast-cats-refuse.md
+++ b/.changeset/fast-cats-refuse.md
@@ -1,0 +1,5 @@
+---
+'@lukemorales/query-key-factory': patch
+---
+
+Fix conflicting types

--- a/src/create-query-key-store.spec.ts
+++ b/src/create-query-key-store.spec.ts
@@ -1,5 +1,6 @@
+import { QueryFunction } from '@tanstack/query-core';
+
 import { createQueryKeyStore } from './create-query-key-store';
-import { QueryFunction } from './query-context.types';
 import { inferQueryKeyStore } from './types';
 
 describe('createQueryKeyStore', () => {

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -1,5 +1,6 @@
+import { QueryFunction } from '@tanstack/query-core';
+
 import { createQueryKeys } from './create-query-keys';
-import { QueryFunction } from './query-context.types';
 import { inferQueryKeys } from './types';
 
 describe('createQueryKeys', () => {

--- a/src/create-query-keys.ts
+++ b/src/create-query-keys.ts
@@ -33,13 +33,15 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
       const value = factory[factoryKey];
       const key = [...mainKey, factoryKey] as const;
 
+      const isReadonlyArray = (arg: unknown): arg is readonly any[] => Array.isArray(arg);
+
       let yieldValue: any;
 
       if (typeof value === 'function') {
         const resultCallback: AnyFactoryOutputCallback = (...args) => {
           const result = value(...args);
 
-          if (Array.isArray(result)) {
+          if (isReadonlyArray(result)) {
             return omitPrototype({
               queryKey: [...key, ...result] as const,
             });
@@ -90,7 +92,7 @@ export function createQueryKeys<Key extends string, Schema extends FactorySchema
         yieldValue = omitPrototype({
           queryKey: key,
         });
-      } else if (Array.isArray(value)) {
+      } else if (isReadonlyArray(value)) {
         yieldValue = omitPrototype({
           _def: key,
           queryKey: [...key, ...value] as const,

--- a/src/internals/types.ts
+++ b/src/internals/types.ts
@@ -36,7 +36,7 @@ type TupleOf<T, N extends number> = number extends N
         : never;
     }[N];
 
-type Length<T extends any[]> = T extends { length: infer L } ? L : never;
+type Length<T extends any[]> = T extends { length: infer L } ? (L extends number ? L : never) : never;
 
 /**
  * @internal

--- a/src/internals/types.ts
+++ b/src/internals/types.ts
@@ -1,9 +1,3 @@
-declare global {
-  interface ArrayConstructor {
-    isArray(arg: readonly any[] | any): arg is readonly any[];
-  }
-}
-
 /**
  * @internal
  */

--- a/src/merge-query-keys.spec.ts
+++ b/src/merge-query-keys.spec.ts
@@ -1,6 +1,7 @@
+import { QueryFunction } from '@tanstack/query-core';
+
 import { createQueryKeys } from './create-query-keys';
 import { mergeQueryKeys } from './merge-query-keys';
-import { QueryFunction } from './query-context.types';
 import { inferQueryKeyStore } from './types';
 
 describe('mergeQueryKeys', () => {

--- a/src/query-context.types.ts
+++ b/src/query-context.types.ts
@@ -1,1 +1,0 @@
-export type { QueryKey, QueryMeta, QueryFunction, QueryFunctionContext } from '@tanstack/query-core';

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,6 @@ import { QueryFunction } from './query-context.types';
 
 type MergeInsertions<T> = T extends object ? { [K in keyof T]: MergeInsertions<T[K]> } : T;
 
-type AnyObject = Record<string, unknown>;
-
 export type AnyQueryKey = readonly [string, ...any[]];
 
 type AnyMutableOrReadonlyArray = any[] | readonly any[];
@@ -13,7 +11,7 @@ type Tuple = [ValidValue, ...Array<ValidValue | undefined>];
 
 export type KeyTuple = Tuple | Readonly<Tuple>;
 
-export type ValidValue = string | number | boolean | AnyObject;
+export type ValidValue = string | number | boolean | object;
 
 type NullableQueryKeyRecord = Record<'queryKey', readonly [ValidValue] | null>;
 
@@ -220,10 +218,10 @@ export type QueryKeyFactoryResult<Key extends string, Schema extends FactorySche
 
 export type AnyQueryKeyFactoryResult = DefinitionKey<[string]> | QueryKeyFactoryResult<string, any>;
 
-type inferRecordQueryKeys<Target extends AnyObject> = {
+type inferRecordQueryKeys<Target extends object> = {
   [P in Exclude<keyof Target, 'queryFn'>]: Target[P] extends AnyMutableOrReadonlyArray
     ? Target[P]
-    : Target[P] extends AnyObject
+    : Target[P] extends object
     ? {
         [K in keyof Target[P]]: inferSchemaProperty<Target[P][K]>;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
+import type { QueryFunction } from '@tanstack/query-core';
+
 import { Add, ExtractInternalKeys } from './internals';
-import { QueryFunction } from './query-context.types';
 
 type MergeInsertions<T> = T extends object ? { [K in keyof T]: MergeInsertions<T[K]> } : T;
 


### PR DESCRIPTION
This PR fixes some type declarations that were causing conflicts and improves support by extending `object` instead of `Record`, allowing types like vue's `Ref` to be accepted.

Fixes #42
Fixes #43 