### PR TITLE
docs: fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ export const todos = createQueryKeys('todos', {
 // {
 //   _def: ['todos'],
 //   detail: (todoId: string) => {
-//     queryKey: ['todos', 'todo', todoId],
+//     queryKey: ['todos', 'detail', todoId],
 //   },
 //   list: (filters: TodoFilters) => {
 //     queryKey: ['todos', 'list', { filters }],
@@ -228,7 +228,7 @@ export const users = createQueryKeys('users', {
 //     queryFn: (ctx: QueryFunctionContext) => api.getUser(userId),
 //     _ctx: {
 //       likes: {
-//         queryKey: ['users', 'detail, userId, 'likes'],
+//         queryKey: ['users', 'detail', userId, 'likes'],
 //         queryFn: (ctx: QueryFunctionContext) => api.getUserLikes(userId),
 //       },
 //     },


### PR DESCRIPTION
I was wondering why the key would be named "todo" when the method is called "detail", then I realized that it's probably a typo. please correct me if I'm wrong.