### PR TITLE
feat: allow empty query and mutation keys

### DIFF
--- a/src/create-mutation-keys.ts
+++ b/src/create-mutation-keys.ts
@@ -48,7 +48,7 @@ export function createMutationKeys<Key extends string, Schema extends MutationFa
             });
           }
 
-          const innerKey = [...key, ...result.mutationKey] as const;
+          const innerKey = [...key, ...(result.mutationKey || [])] as const;
 
           if ('mutationFn' in result) {
             const queryOptions = {

--- a/src/create-query-keys.ts
+++ b/src/create-query-keys.ts
@@ -48,7 +48,7 @@ export function createQueryKeys<Key extends string, Schema extends QueryFactoryS
             });
           }
 
-          const innerKey = [...key, ...result.queryKey] as const;
+          const innerKey = [...key, ...(result.queryKey || [])] as const;
 
           if ('queryFn' in result) {
             // type $QueryFnContext = Omit<QueryFunctionContext<typeof innerKey, any>, 'queryKey'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,11 +55,11 @@ type DynamicMutationKeySchemaWithContextualMutations = MutationKeyRecord & {
   contextMutations: MutationFactorySchema;
 };
 
-type DynamicQueryFactorySchema = QueryKeyRecord & {
+type DynamicQueryFactorySchema = Partial<QueryKeyRecord> & {
   queryFn: QueryFunction;
 };
 
-type DynamicMutationFactorySchema = MutationKeyRecord & {
+type DynamicMutationFactorySchema = Partial<MutationKeyRecord> & {
   mutationFn: MutateFunction;
 };
 


### PR DESCRIPTION
Do we need to make it mandatory? I believe it could be beneficial to avoid writing `queryKey` and `mutationKey` and instead pass just a function, as it would reduce the amount of code.