### PR TITLE
fix: Loosen types for `TypedUseQueryOptions`

### DIFF
--- a/.changeset/hot-tips-prove.md
+++ b/.changeset/hot-tips-prove.md
@@ -1,0 +1,5 @@
+---
+'@lukemorales/query-key-factory': patch
+---
+
+Loosen types for `TypedUseQueryOptions` and allow inference of dynamic query options generation


### PR DESCRIPTION
Fixes #59 