### PR TITLE
fix: Repair type inference allowing extra keys

### DIFF
--- a/.changeset/light-lies-search.md
+++ b/.changeset/light-lies-search.md
@@ -1,0 +1,5 @@
+---
+'@lukemorales/query-key-factory': patch
+---
+
+Fix type inference allowing extra keys

--- a/src/create-mutation-keys.spec.ts
+++ b/src/create-mutation-keys.spec.ts
@@ -40,7 +40,7 @@ describe('createMutationKeys', () => {
           _def: ['trying to override the _def key value'],
           prop: null,
         }),
-      ).toThrow('Keys that start with "_" are reserved for the Query Key Factory');
+      ).toThrow('Keys that start with "_" are reserved for Query Key Factory');
 
       expect(() =>
         createMutationKeys('users', {
@@ -48,7 +48,7 @@ describe('createMutationKeys', () => {
           _my_own_key: ['trying to create with the shape of an internal key'],
           prop: null,
         }),
-      ).toThrow('Keys that start with "_" are reserved for the Query Key Factory');
+      ).toThrow('Keys that start with "_" are reserved for Query Key Factory');
     });
 
     describe('when the schema property is not a function', () => {

--- a/src/create-mutation-keys.types.ts
+++ b/src/create-mutation-keys.types.ts
@@ -1,6 +1,6 @@
 import type { MutateFunction } from '@tanstack/query-core';
 
-import type { ExtractInternalKeys } from './internals';
+import type { ExtractInternalKeys, InternalKey } from './internals';
 import type { KeyTuple, AnyMutableOrReadonlyArray, DefinitionKey } from './types';
 
 export type AnyMutationKey = readonly [string, ...any[]];
@@ -54,7 +54,7 @@ type MutationDynamicKey = (
 
 export type MutationFactorySchema = Record<string, MutationFactoryProperty | MutationDynamicKey>;
 
-type InvalidSchema<Schema extends MutationFactorySchema> = Omit<Schema, `_${string}`>;
+type InvalidSchema<Schema extends MutationFactorySchema> = Omit<Schema, InternalKey>;
 
 export type ValidateFactory<Schema extends MutationFactorySchema> = Schema extends {
   [P in ExtractInternalKeys<Schema>]: Schema[P];

--- a/src/create-query-keys.spec.ts
+++ b/src/create-query-keys.spec.ts
@@ -36,19 +36,19 @@ describe('createQueryKeys', () => {
     it('throws an error if the schema contains a key that starts with "_"', () => {
       expect(() =>
         createQueryKeys('users', {
-          // @ts-expect-error: "_def" should not be an allowed key
+          // @ts-expect-error: "_myOwnKey" should not be an allowed key
           _def: ['trying to override the _def key value'],
           prop: null,
         }),
-      ).toThrow('Keys that start with "_" are reserved for the Query Key Factory');
+      ).toThrow('Keys that start with "_" are reserved for Query Key Factory');
 
       expect(() =>
         createQueryKeys('users', {
-          // @ts-expect-error: "_my_own_key" should not be an allowed key
-          _my_own_key: ['trying to create with the shape of an internal key'],
+          // @ts-expect-error: "_myOwnKey" should not be an allowed key
+          _myOwnKey: ['trying to create with the shape of an internal key'],
           prop: null,
         }),
-      ).toThrow('Keys that start with "_" are reserved for the Query Key Factory');
+      ).toThrow('Keys that start with "_" are reserved for Query Key Factory');
     });
 
     describe('when the schema property is not a function', () => {

--- a/src/create-query-keys.ts
+++ b/src/create-query-keys.ts
@@ -12,11 +12,11 @@ export function createQueryKeys<Key extends string>(queryDef: Key): DefinitionKe
 export function createQueryKeys<Key extends string, Schema extends QueryFactorySchema>(
   queryDef: Key,
   schema: ValidateFactory<Schema>,
-): QueryKeyFactoryResult<Key, Schema>;
+): QueryKeyFactoryResult<Key, ValidateFactory<Schema>>;
 export function createQueryKeys<Key extends string, Schema extends QueryFactorySchema>(
   queryDef: Key,
   schema?: ValidateFactory<Schema>,
-): DefinitionKey<[Key]> | QueryKeyFactoryResult<Key, Schema> {
+): DefinitionKey<[Key]> | QueryKeyFactoryResult<Key, ValidateFactory<Schema>> {
   const defKey: DefinitionKey<[Key]> = {
     _def: [queryDef] as const,
   };

--- a/src/create-query-keys.types.ts
+++ b/src/create-query-keys.types.ts
@@ -1,6 +1,6 @@
 import type { QueryFunction } from '@tanstack/query-core';
 
-import type { ExtractInternalKeys } from './internals';
+import type { ExtractInternalKeys, InternalKey } from './internals';
 import type { KeyTuple, AnyMutableOrReadonlyArray, DefinitionKey } from './types';
 
 export type AnyQueryKey = readonly [string, ...any[]];
@@ -54,7 +54,7 @@ type DynamicKey = (
 
 export type QueryFactorySchema = Record<string, FactoryProperty | DynamicKey>;
 
-type InvalidSchema<Schema extends QueryFactorySchema> = Omit<Schema, `_${string}`>;
+type InvalidSchema<Schema extends QueryFactorySchema> = Omit<Schema, InternalKey>;
 
 export type ValidateFactory<Schema extends QueryFactorySchema> = Schema extends {
   [P in ExtractInternalKeys<Schema>]: Schema[P];

--- a/src/create-query-keys.types.ts
+++ b/src/create-query-keys.types.ts
@@ -60,7 +60,9 @@ export type ValidateFactory<Schema extends QueryFactorySchema> = Schema extends 
   [P in ExtractInternalKeys<Schema>]: Schema[P];
 }
   ? InvalidSchema<Schema>
-  : Schema;
+  : {
+      [P in keyof Schema]: Schema[P];
+    };
 
 type ExtractNullableKey<Key extends KeyTuple | null | undefined> = Key extends
   | [...infer Value]

--- a/src/internals/assert-schema-keys.ts
+++ b/src/internals/assert-schema-keys.ts
@@ -7,7 +7,7 @@ export const assertSchemaKeys = (schema: Record<string, unknown>): string[] => {
   const hasKeyInShapeOfInternalKey = keys.some((key) => key.startsWith('_'));
 
   if (hasKeyInShapeOfInternalKey) {
-    throw new Error('Keys that start with "_" are reserved for the Query Key Factory');
+    throw new Error('Keys that start with "_" are reserved for Query Key Factory');
   }
 
   return keys;

--- a/src/internals/types.ts
+++ b/src/internals/types.ts
@@ -1,7 +1,12 @@
 /**
  * @internal
  */
-export type ExtractInternalKeys<T extends Record<string, unknown>> = Extract<keyof T, `_${string}`>;
+export type InternalKey = `_${string}`;
+
+/**
+ * @internal
+ */
+export type ExtractInternalKeys<T extends Record<string, unknown>> = Extract<keyof T, InternalKey>;
 
 /**
  * Math types for iterating over `mergeQueryKeys` schemas and


### PR DESCRIPTION
Fixes #69 