### PR TITLE
docs: add documentation for optional `queryKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ export const todos = createQueryKeys('todos', {
 // }
 ```
 
+`queryKey` can be optional when there's no need for a dynamic query:
+
+```ts
+export const users = createQueryKeys('users', {
+  list: {
+    queryKey: null,
+    queryFn: () => api.getUsers(),
+  }
+});
+```
+
 ### Generate the query options you need to run `useQuery`
 Declare your `queryKey` and your `queryFn` together, and have easy access to everything you need to run a query:
 


### PR DESCRIPTION
Regarding the issue #75, I also had the confusion where typescript complains about `queryKey` being `null` when using function to create a query.

I added some documentation with an example under the 'Standardized keys' section.
Hope this clears up the confusion :)